### PR TITLE
Fix falsy check in extractNamesFromJson

### DIFF
--- a/app/components/index.tsx
+++ b/app/components/index.tsx
@@ -93,9 +93,8 @@ const Main: FC<IMainProps> = () => {
    * @returns 提取的名称，用'-'连接
    */
   const extractNamesFromJson = (jsonStr: string | undefined | null): string => {
-    if (jsonStr == undefined||null||"") {
+    if (!jsonStr)
       return ''
-    }
     try {
       const data = JSON.parse(jsonStr)
       const names = Object.keys(data)


### PR DESCRIPTION
## Summary
- fix invalid JSON string check by using `!jsonStr`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686778d09010832f9cef4680f2fdb4a0